### PR TITLE
fix python code in SIGNEXTEND opcode

### DIFF
--- a/04_ArithmeticOp/readme.md
+++ b/04_ArithmeticOp/readme.md
@@ -291,11 +291,13 @@ print(evm.stack)
             raise Exception('Stack underflow')
         b = self.stack.pop()
         x = self.stack.pop()
-        if b < 32: # 如果b>=32，则不需要扩展
-            sign_bit = 1 << (8 * b - 1) # b 字节的最高位（符号位）对应的掩码值，将用来检测 x 的符号位是否为1
-            x = x & ((1 << (8 * b)) - 1)  # 对 x 进行掩码操作，保留 x 的前 b+1 字节的值，其余字节全部置0
+        if b < 31: # 如果b>=31，则不需要扩展
+            sign_bit = 1 << (8 * (b + 1) - 1) # 第 b 字节的最高位（符号位）对应的掩码值，将用来检测 x 的符号位是否为1
+            mask = (1 << (8 * (b + 1))) - 1 # 前 b+1 字节对应的掩码
+            x = x & mask  # 对 x 进行掩码操作，保留 x 的前 b+1 字节的值，其余字节全部置0
             if x & sign_bit:  # 检查 x 的符号位是否为1
-                x = x | ~((1 << (8 * b)) - 1)  # 将 x 的剩余部分全部置1
+                x = x | ~mask  # 将 x 的剩余部分全部置1
+                x = x %（2**256） # 置1后 x 为负数，取余变回非负数
         self.stack.append(x)
     ```
 


### PR DESCRIPTION
1. `b == 31`时，b 为最高字节位，不需要扩展。
2. `b`取 `0`时，`8 * b - 1`为`-1`，明显可以看出原来的代码有错。操作数都是 256 bit，字节位是从 0 到 31，所以应该是`8 * (b + 1) - 1`。
3. 置1后，需要取余将结果变回 256 bit 非负数。